### PR TITLE
fix: correct midpoint calculation in convert_point_to_coordinates

### DIFF
--- a/codes/ui_tars/action_parser.py
+++ b/codes/ui_tars/action_parser.py
@@ -16,8 +16,8 @@ def convert_point_to_coordinates(text, is_answer=False):
 
     def replace_match(match):
         x1, y1 = map(int, match.groups())
-        x = (x1 + x1) // 2  # 使用截断取整
-        y = (y1 + y1) // 2  # 使用截断取整
+        x = (x1 + x2) // 2  # 使用截断取整
+        y = (y1 + y2) // 2  # 使用截断取整
         if is_answer:
             return f"({x},{y})"  # 只返回 (x, y) 格式
         return f"({x},{y})"  # 返回带标签的格式


### PR DESCRIPTION
Closes #242

## Problem
In `codes/ui_tars/action_parser.py`, the `convert_point_to_coordinates` function incorrectly computes the center of a point using `x1+x1` and `y1+y1` instead of `x1+x2` and `y1+y2`. This copy-paste error causes the function to always return the top-left corner `(x1, y1)` of the bounding box instead of its actual center.

```python
# BUG (before)
x = (x1 + x1) // 2
y = (y1 + y1) // 2

# FIX (after)
x = (x1 + x2) // 2
y = (y1 + y2) // 2
```

## Impact
All point-to-coordinate conversions silently return the wrong location, leading to incorrect click/interaction targets in the UI agent.